### PR TITLE
Map .xslt extension to XML icon

### DIFF
--- a/fileicons/material-icons.json
+++ b/fileicons/material-icons.json
@@ -234,6 +234,7 @@
 		"xsd": "_file_xml",
 		"dtd": "_file_xml",
 		"xsl": "_file_xml",
+		"xslt": "_file_xml",
 		"resx": "_file_xml",
 		"iml": "_file_xml",
 		"xquery": "_file_xml",


### PR DESCRIPTION
Why nobody else uses .xslt extension? Is it really only me? May be it is me, who is wrong here? 😨