### PR TITLE
Add YAML-tmLanguage & tmLanguage

### DIFF
--- a/fileicons/material-icons.json
+++ b/fileicons/material-icons.json
@@ -280,6 +280,7 @@
 		"resx": "_file_xml",
 		"iml": "_file_xml",
 		"xquery": "_file_xml",
+		"tmLanguage": "_file_xml",
 		"png": "_file_image",
 		"jpeg": "_file_image",
 		"jpg": "_file_image",

--- a/fileicons/material-icons.json
+++ b/fileicons/material-icons.json
@@ -270,6 +270,7 @@
 		"less": "_file_css",
 		"json": "_file_json",
 		"yaml": "_file_yaml",
+		"YAML-tmLanguage": "_file_yaml",
 		"yml": "_file_yaml",
 		"xml": "_file_xml",
 		"xsd": "_file_xml",


### PR DESCRIPTION
The `YAML-tmLanguage` extension is used by Sublime Text's PackageDev & VS Code for writing language packages. They're converted to Plist XML files with the `tmLanguage` extension for use with both.

This identifies them both as YAML/XML formats.