### PR TITLE
Use Clojure icon for ClojureScript

### DIFF
--- a/src/material-icons.json
+++ b/src/material-icons.json
@@ -515,6 +515,7 @@
 		"vb": "_file_vs",
 		"lua": "_file_lua",
 		"clj": "_file_clojure",
+		"cljs": "_file_clojure",
 		"groovy": "_file_groovy",
 		"r": "_file_r",
 		"rst": "_file_markdown",


### PR DESCRIPTION
This PR adds icon support for ClojureScript with `*.cljs` file extension